### PR TITLE
Recommend Visual Studio Code Extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,24 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"eamodio.gitlens",
+		"redhat.java",
+		"vscjava.vscode-gradle",
+		"vscjava.vscode-java-debug",
+		"vscjava.vscode-java-dependency",
+		"vscjava.vscode-java-pack",
+		"vscjava.vscode-java-test",
+		"vscjava.vscode-maven",
+		"vscjava.vscode-spring-boot-dashboard",
+		"georgewfraser.vscode-javac",
+		"GitHub.copilot",
+		"GitHub.vscode-pull-request-github"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -18,7 +18,5 @@
 		"GitHub.vscode-pull-request-github"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-		
-	]
+	"unwantedRecommendations": []
 }


### PR DESCRIPTION
- IntelliJ is great for usage purposes, but sometimes one's favourite IDE is based on personal preferences
- For anyone who might want to run CLInkedIn in Visual Studio Code instead, let's recommend them a list of extensions to install in order to help get their project running
- The recommendations will automatically open when someone opens the repository in Visual Studio Code, and will help the user build the project successfully.