### PR TITLE
Add FindLocation Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindLocationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindLocationCommand.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.LocationContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindLocationCommand extends Command {
+
+    public static final String COMMAND_WORD = "findLocation";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose address contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " singapore";
+
+    private final LocationContainsKeywordsPredicate predicate;
+
+    public FindLocationCommand(LocationContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindLocationCommand // instanceof handles nulls
+                && predicate.equals(((FindLocationCommand) other).predicate)); // state check
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,16 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.FindNameCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -62,6 +53,9 @@ public class AddressBookParser {
 
         case FindNameCommand.COMMAND_WORD:
             return new FindNameCommandParser().parse(arguments);
+
+        case FindLocationCommand.COMMAND_WORD:
+            return new FindLocationCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindLocationCommand;
 import seedu.address.logic.commands.FindNameCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;

--- a/src/main/java/seedu/address/logic/parser/FindLocationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindLocationCommandParser.java
@@ -4,30 +4,31 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.Arrays;
 
-import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindLocationCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.DetailsContainKeywordsPredicate;
+import seedu.address.model.person.LocationContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
-public class FindCommandParser implements Parser<FindCommand> {
+public class FindLocationCommandParser implements Parser<FindLocationCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public FindCommand parse(String args) throws ParseException {
+    public FindLocationCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindLocationCommand.MESSAGE_USAGE));
         }
 
-        String[] detailsKeywords = trimmedArgs.split("\\s+");
+        String[] locationKeywords = trimmedArgs.split("\\s+");
 
-        return new FindCommand(new DetailsContainKeywordsPredicate(Arrays.asList(detailsKeywords)));
+        return new FindLocationCommand(new LocationContainsKeywordsPredicate(Arrays.asList(locationKeywords)));
     }
+
 
 }

--- a/src/main/java/seedu/address/model/person/LocationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/LocationContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Address} matches any of the keywords given.
+ */
+public class LocationContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public LocationContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAddress().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof LocationContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((LocationContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/FindLocationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindLocationCommandTest.java
@@ -1,0 +1,84 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.LocationContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ */
+public class FindLocationCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        LocationContainsKeywordsPredicate firstPredicate =
+                new LocationContainsKeywordsPredicate(Collections.singletonList("first"));
+        LocationContainsKeywordsPredicate secondPredicate =
+                new LocationContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FindLocationCommand findFirstCommand = new FindLocationCommand(firstPredicate);
+        FindLocationCommand findSecondCommand = new FindLocationCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindLocationCommand findFirstCommandCopy = new FindLocationCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        LocationContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindLocationCommand command = new FindLocationCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        LocationContainsKeywordsPredicate predicate = preparePredicate("jurong clementi tokyo");
+        FindLocationCommand command = new FindLocationCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, FIONA), model.getFilteredPersonList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private LocationContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new LocationContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/FindLocationCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindLocationCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindLocationCommand;
+import seedu.address.model.person.LocationContainsKeywordsPredicate;
+
+public class FindLocationCommandParserTest {
+
+    private FindLocationCommandParser parser = new FindLocationCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindLocationCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindLocationCommand expectedFindLocationCommand =
+                new FindLocationCommand(new LocationContainsKeywordsPredicate(Arrays.asList("jurong", "clementi")));
+        assertParseSuccess(parser, "jurong clementi", expectedFindLocationCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n jurong \n \t clementi  \t", expectedFindLocationCommand);
+    }
+}


### PR DESCRIPTION
#19 

Previously, there is only the general `FindCommand` that returns persons whose names, addresses, emails, tags and statuses contains the keywords.

Let's add a more specific command to display search results of a certain attribute, in this case returns persons whose **addresses** fit the keywords.