### PR TITLE
Add FindEmailCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindEmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindEmailCommand.java
@@ -7,7 +7,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons in address book whose email contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindEmailCommand extends Command {

--- a/src/main/java/seedu/address/logic/commands/FindEmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindEmailCommand.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindEmailCommand extends Command {
+
+    public static final String COMMAND_WORD = "findEmail";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose email contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " gmail";
+
+    private final EmailContainsKeywordsPredicate predicate;
+
+    public FindEmailCommand(EmailContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindEmailCommand // instanceof handles nulls
+                && predicate.equals(((FindEmailCommand) other).predicate)); // state check
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindEmailCommand;
 import seedu.address.logic.commands.FindLocationCommand;
 import seedu.address.logic.commands.FindNameCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -65,6 +66,9 @@ public class AddressBookParser {
 
         case FindNameCommand.COMMAND_WORD:
             return new FindNameCommandParser().parse(arguments);
+
+        case FindEmailCommand.COMMAND_WORD:
+            return new FindEmailCommandParser().parse(arguments);
 
         case FindLocationCommand.COMMAND_WORD:
             return new FindLocationCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/FindEmailCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindEmailCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FindEmailCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class FindEmailCommandParser implements Parser<FindEmailCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindEmailCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindEmailCommand.MESSAGE_USAGE));
+        }
+
+        String[] locationKeywords = trimmedArgs.split("\\s+");
+
+        return new FindEmailCommand(new EmailContainsKeywordsPredicate(Arrays.asList(locationKeywords)));
+    }
+
+
+}

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Email} matches any of the keywords given.
+ */
+public class EmailContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public EmailContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsSequenceIgnoreCase(person.getEmail().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EmailContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((EmailContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/LocationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/LocationContainsKeywordsPredicate.java
@@ -8,8 +8,9 @@ import seedu.address.commons.util.StringUtil;
 /**
  * Tests that a {@code Person}'s {@code Address} matches any of the keywords given.
  */
-public class LocationContainsKeywordsPredicate implements Predicate<Person> {
-    private final List<String> keywords;
+public class LocationContainsKeywordsPredicate
+        implements Predicate<Person> {
+    final List<String> keywords;
 
     public LocationContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;

--- a/src/test/java/seedu/address/logic/commands/FindEmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindEmailCommandTest.java
@@ -18,30 +18,30 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.LocationContainsKeywordsPredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code FindLocationCommand}.
+ * Contains integration tests (interaction with the Model) for {@code FindEmailCommand}.
  */
-public class FindLocationCommandTest {
+public class FindEmailCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void equals() {
-        LocationContainsKeywordsPredicate firstPredicate =
-                new LocationContainsKeywordsPredicate(Collections.singletonList("first"));
-        LocationContainsKeywordsPredicate secondPredicate =
-                new LocationContainsKeywordsPredicate(Collections.singletonList("second"));
+        EmailContainsKeywordsPredicate firstPredicate =
+                new EmailContainsKeywordsPredicate(Collections.singletonList("first"));
+        EmailContainsKeywordsPredicate secondPredicate =
+                new EmailContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindLocationCommand findFirstCommand = new FindLocationCommand(firstPredicate);
-        FindLocationCommand findSecondCommand = new FindLocationCommand(secondPredicate);
+        FindEmailCommand findFirstCommand = new FindEmailCommand(firstPredicate);
+        FindEmailCommand findSecondCommand = new FindEmailCommand(secondPredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindLocationCommand findFirstCommandCopy = new FindLocationCommand(firstPredicate);
+        FindEmailCommand findFirstCommandCopy = new FindEmailCommand(firstPredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -57,8 +57,8 @@ public class FindLocationCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        LocationContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindLocationCommand command = new FindLocationCommand(predicate);
+        EmailContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindEmailCommand command = new FindEmailCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
@@ -67,18 +67,18 @@ public class FindLocationCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        LocationContainsKeywordsPredicate predicate = preparePredicate("jurong clementi tokyo");
-        FindLocationCommand command = new FindLocationCommand(predicate);
+        EmailContainsKeywordsPredicate predicate = preparePredicate("alice johnd lydia");
+        FindEmailCommand command = new FindEmailCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE, BENSON, FIONA), model.getFilteredPersonList());
     }
 
     /**
-     * Parses {@code userInput} into a {@code LocationContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code EmailContainsKeywordsPredicate}.
      */
-    private LocationContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new LocationContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private EmailContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new EmailContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindEmailCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindEmailCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindEmailCommand;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+
+public class FindEmailCommandParserTest {
+
+    private FindEmailCommandParser parser = new FindEmailCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindEmailCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindEmailCommand expectedFindLocationCommand =
+                new FindEmailCommand(new EmailContainsKeywordsPredicate(Arrays.asList("alice", "johnd")));
+        assertParseSuccess(parser, "alice johnd", expectedFindLocationCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n alice \n \t johnd  \t", expectedFindLocationCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindEmailCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindEmailCommandParserTest.java
@@ -24,11 +24,11 @@ public class FindEmailCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindEmailCommand expectedFindLocationCommand =
+        FindEmailCommand expectedFindEmailCommand =
                 new FindEmailCommand(new EmailContainsKeywordsPredicate(Arrays.asList("alice", "johnd")));
         assertParseSuccess(parser, "alice johnd", expectedFindLocationCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n alice \n \t johnd  \t", expectedFindLocationCommand);
+        assertParseSuccess(parser, " \n alice \n \t johnd  \t", expectedFindEmailCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindEmailCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindEmailCommandParserTest.java
@@ -26,7 +26,7 @@ public class FindEmailCommandParserTest {
         // no leading and trailing whitespaces
         FindEmailCommand expectedFindEmailCommand =
                 new FindEmailCommand(new EmailContainsKeywordsPredicate(Arrays.asList("alice", "johnd")));
-        assertParseSuccess(parser, "alice johnd", expectedFindLocationCommand);
+        assertParseSuccess(parser, "alice johnd", expectedFindEmailCommand);
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n alice \n \t johnd  \t", expectedFindEmailCommand);

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -31,7 +31,7 @@ public class TypicalPersons {
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
-    public static final Person        CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
+    public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -31,7 +31,7 @@ public class TypicalPersons {
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
-    public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
+    public static final Person        CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();


### PR DESCRIPTION
#79 
Previously, there is only the general FindCommand that returns persons whose names, addresses, emails, tags and statuses contains the keywords.

Let's add a more specific command to display search results of a certain attribute, in this case returns persons whose emails fit the keywords.