### PR TITLE
Add FindPhoneCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindPhoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPhoneCommand.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Finds and lists all persons in address book whose phone number contains any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindPhoneCommand extends Command {
+
+    public static final String COMMAND_WORD = "findphone";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose phone numbers contain any of "
+            + "the sequence of numbers and displays them as a list with index phones.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " 86671234 91234567";
+
+    private final PhoneContainsKeywordsPredicate predicate;
+
+    public FindPhoneCommand(PhoneContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindPhoneCommand // instanceof handles nulls
+                && predicate.equals(((FindPhoneCommand) other).predicate)); // state check
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/commands/FindPhoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPhoneCommand.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Finds and lists all persons in address book whose phone number contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.FindLocationCommand;
 import seedu.address.logic.commands.FindNameCommand;
+import seedu.address.logic.commands.FindPhoneCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -68,6 +69,9 @@ public class AddressBookParser {
 
         case FindLocationCommand.COMMAND_WORD:
             return new FindLocationCommandParser().parse(arguments);
+
+        case FindPhoneCommand.COMMAND_WORD:
+            return new FindPhoneCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/FindPhoneCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPhoneCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.FindPhoneCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class FindPhoneCommandParser implements Parser<FindPhoneCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindPhoneCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPhoneCommand.MESSAGE_USAGE));
+        }
+
+        String[] phoneKeywords = trimmedArgs.split("\\s+");
+
+        return new FindPhoneCommand(new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/parser/FindPhoneCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPhoneCommandParser.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.FindPhoneCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import seedu.address.logic.commands.FindPhoneCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Address} matches any of the keywords given.
+ */
+public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsSequenceIgnoreCase(person.getPhone().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PhoneContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((PhoneContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,9 +1,9 @@
 package seedu.address.model.person;
 
-import seedu.address.commons.util.StringUtil;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Person}'s {@code Address} matches any of the keywords given.

--- a/src/test/java/seedu/address/logic/commands/FindPhoneCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPhoneCommandTest.java
@@ -1,18 +1,25 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.*;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.

--- a/src/test/java/seedu/address/logic/commands/FindPhoneCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPhoneCommandTest.java
@@ -1,0 +1,78 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.*;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ */
+public class FindPhoneCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        PhoneContainsKeywordsPredicate firstPredicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("91234567"));
+        PhoneContainsKeywordsPredicate secondPredicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("86671234"));
+
+        FindPhoneCommand findFirstCommand = new FindPhoneCommand(firstPredicate);
+        FindPhoneCommand findSecondCommand = new FindPhoneCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindPhoneCommand findFirstCommandCopy = new FindPhoneCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(91234567));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different phone -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        PhoneContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindPhoneCommand command = new FindPhoneCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        PhoneContainsKeywordsPredicate predicate = preparePredicate("9435 654 2427");
+        FindPhoneCommand command = new FindPhoneCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, FIONA), model.getFilteredPersonList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private PhoneContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new PhoneContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/FindPhoneCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindPhoneCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.FindPhoneCommand;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+public class FindPhoneCommandParserTest {
+
+    private FindPhoneCommandParser parser = new FindPhoneCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPhoneCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindPhoneCommand expectedFindPhoneCommand =
+                new FindPhoneCommand(new PhoneContainsKeywordsPredicate(Arrays.asList("9435", "654")));
+        assertParseSuccess(parser, "9435 654", expectedFindPhoneCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n 9435 \n \t 654  \t", expectedFindPhoneCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindPhoneCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindPhoneCommandParserTest.java
@@ -1,14 +1,15 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.logic.commands.FindPhoneCommand;
-import seedu.address.model.person.PhoneContainsKeywordsPredicate;
-
-import java.util.Arrays;
-
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindPhoneCommand;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 public class FindPhoneCommandParserTest {
 


### PR DESCRIPTION
Currently, there is only a general Find Command that returns persons
whose names, addresses, emails, tags and statuses contain the keywords.

Let's add a more specific command to display search results of a certain attribute.
This command returns persons whose phone numbers fit the string of number keywords.
Let's also add the appropriate JUnit tests for this feature.

Closes #82 
#16