### PR TITLE
Update parser to be case-insensitive when checking commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindEmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindEmailCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.EmailContainsKeywordsPredicate;
  */
 public class FindEmailCommand extends Command {
 
-    public static final String COMMAND_WORD = "findEmail";
+    public static final String COMMAND_WORD = "findemail";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose email contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/commands/FindLocationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindLocationCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.LocationContainsKeywordsPredicate;
  */
 public class FindLocationCommand extends Command {
 
-    public static final String COMMAND_WORD = "findLocation";
+    public static final String COMMAND_WORD = "findlocation";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose address contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/commands/FindNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindNameCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
  */
 public class FindNameCommand extends Command {
 
-    public static final String COMMAND_WORD = "findName";
+    public static final String COMMAND_WORD = "findname";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -46,7 +46,7 @@ public class AddressBookParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
 


### PR DESCRIPTION
Updated AddressBookParser.java to be case-insensitive when checking commands by converting to lowercase.

`Note:` As such, in the future, any command classes should define their COMMAND_WORD in lowercase.