### PR TITLE
Add stats command to view statistics of candidates

### DIFF
--- a/src/main/java/seedu/clinkedin/commons/core/Messages.java
+++ b/src/main/java/seedu/clinkedin/commons/core/Messages.java
@@ -9,5 +9,10 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-
+    public static final String MESSAGE_STATS_DISPLAYED_OVERVIEW = "Statistics displayed!\n"
+            + "Number of persons used to calculate statistics: %5$d\n"
+            + "Average tags per person: %1$.2f\n"
+            + "Highest number of tags a single person has: %2$.0f\n"
+            + "Lowest number of tags a single person has: %3$.0f\n"
+            + "Total number of tags added in ClInkedIn: %4$.0f";
 }

--- a/src/main/java/seedu/clinkedin/commons/core/Messages.java
+++ b/src/main/java/seedu/clinkedin/commons/core/Messages.java
@@ -14,5 +14,5 @@ public class Messages {
             + "Average tags per person: %1$.2f\n"
             + "Highest number of tags a single person has: %2$.0f\n"
             + "Lowest number of tags a single person has: %3$.0f\n"
-            + "Total number of tags added in ClInkedIn: %4$.0f";
+            + "Total number of tags added to displayed persons: %4$.0f";
 }

--- a/src/main/java/seedu/clinkedin/logic/commands/StatsCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/StatsCommand.java
@@ -1,0 +1,39 @@
+package seedu.clinkedin.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.DoubleSummaryStatistics;
+
+import seedu.clinkedin.commons.core.Messages;
+import seedu.clinkedin.model.Model;
+
+/**
+ * Calculates and displays the statistics of the persons in the user's ClInkedIn.
+ * Uses the DoubleSummaryStatistics class to calculate the statistics.
+ * Only the persons currently displayed in the user's ClInkedIn will be used to calculate the statistics. i.e. the
+ * statistics will not include persons that are filtered out by the user.
+ */
+public class StatsCommand extends Command {
+
+    public static final String COMMAND_WORD = "stats";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Calculates and displays the statistics of the persons "
+            + "in the user's ClInkedIn.\n"
+            + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        DoubleSummaryStatistics stats = model.setStats();
+        return new CommandResult(String.format(
+                Messages.MESSAGE_STATS_DISPLAYED_OVERVIEW, stats.getAverage(), stats.getMax(), stats.getMin(),
+                stats.getSum(), stats.getCount()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof StatsCommand // instanceof handles nulls
+                ); // state check
+    }
+}

--- a/src/main/java/seedu/clinkedin/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/AddressBookParser.java
@@ -21,6 +21,7 @@ import seedu.clinkedin.logic.commands.FindCommand;
 import seedu.clinkedin.logic.commands.HelpCommand;
 import seedu.clinkedin.logic.commands.ListCommand;
 import seedu.clinkedin.logic.commands.NoteCommand;
+import seedu.clinkedin.logic.commands.StatsCommand;
 import seedu.clinkedin.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case StatsCommand.COMMAND_WORD:
+            return new StatsCommand();
 
         case AddTagCommand.COMMAND_WORD:
             return new AddTagCommandParser().parse(arguments);

--- a/src/main/java/seedu/clinkedin/model/Model.java
+++ b/src/main/java/seedu/clinkedin/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.clinkedin.model;
 
 import java.nio.file.Path;
+import java.util.DoubleSummaryStatistics;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -78,6 +79,11 @@ public interface Model {
      * existing person in the clinkedin book.
      */
     void setPerson(Person target, Person editedPerson);
+
+    /**
+     * Returns a summary of the statistics of the persons in the clinkedin book.
+     */
+    DoubleSummaryStatistics setStats();
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/clinkedin/model/ModelManager.java
+++ b/src/main/java/seedu/clinkedin/model/ModelManager.java
@@ -5,6 +5,7 @@ import static seedu.clinkedin.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.DoubleSummaryStatistics;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -120,6 +121,19 @@ public class ModelManager implements Model {
     @Override
     public int getTotalNumberOfPersons() {
         return addressBook.getCount();
+    }
+
+    /**
+     * Returns a summary of the statistics of the persons' tags in the user's ClInkedIn using the
+     * DoubleSummaryStatistics class.
+     * @return a DoubleSummaryStatistics object containing the tag statistics of the persons in the user's ClInkedIn.
+     */
+    @Override
+    public DoubleSummaryStatistics setStats() {
+        DoubleSummaryStatistics stats = filteredPersons.stream().mapToDouble(Person::getTagCount).collect(
+                DoubleSummaryStatistics::new, DoubleSummaryStatistics::accept, DoubleSummaryStatistics::combine);
+        logger.fine("Stats: " + stats);
+        return stats;
     }
 
     // =========== Filtered Person List Accessors

--- a/src/main/java/seedu/clinkedin/model/person/Person.java
+++ b/src/main/java/seedu/clinkedin/model/person/Person.java
@@ -88,6 +88,10 @@ public class Person {
         return status;
     }
 
+    public int getTagCount() {
+        return tagTypeMap.getTagCount();
+    }
+
     /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.

--- a/src/main/java/seedu/clinkedin/model/person/UniqueTagTypeMap.java
+++ b/src/main/java/seedu/clinkedin/model/person/UniqueTagTypeMap.java
@@ -215,6 +215,15 @@ public class UniqueTagTypeMap implements Iterable<TagType> {
         return internalMap.size();
     }
 
+    public int getTagCount() {
+        int count = 0;
+        for (TagType t: this) {
+            assert this.getTagList(t) != null;
+            count += this.getTagList(t).getCount();
+        }
+        return count;
+    }
+
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */

--- a/src/test/java/seedu/clinkedin/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.clinkedin.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.DoubleSummaryStatistics;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -166,6 +167,11 @@ public class AddCommandTest {
 
         @Override
         public int getFilteredNumberOfPersons() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public DoubleSummaryStatistics setStats() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/clinkedin/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddTagCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.clinkedin.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.DoubleSummaryStatistics;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -157,6 +158,11 @@ public class AddTagCommandTest {
 
         @Override
         public int getFilteredNumberOfPersons() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public DoubleSummaryStatistics setStats() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/clinkedin/logic/commands/StatsCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/StatsCommandTest.java
@@ -1,0 +1,41 @@
+package seedu.clinkedin.logic.commands;
+
+import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinkedin.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinkedin.model.Model;
+import seedu.clinkedin.model.ModelManager;
+import seedu.clinkedin.model.UserPrefs;
+
+class StatsCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    void execute_unfilteredList_success() {
+        StatsCommand statsCommand = new StatsCommand();
+        String expectedMessage = "Statistics displayed!\n"
+                + "Number of persons used to calculate statistics: 7\n"
+                + "Average tags per person: 0.57\n"
+                + "Highest number of tags a single person has: 2\n"
+                + "Lowest number of tags a single person has: 0\n"
+                + "Total number of tags added to displayed persons: 4";
+        assertCommandSuccess(statsCommand, model, expectedMessage, model);
+    }
+
+    @Test
+void execute_filteredList_success() {
+        Model filteredModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        filteredModel.updateFilteredPersonList(p -> p.getName().fullName.equals("Alice Pauline"));
+        StatsCommand statsCommand = new StatsCommand();
+        String expectedMessage = "Statistics displayed!\n"
+                + "Number of persons used to calculate statistics: 1\n"
+                + "Average tags per person: 1.00\n"
+                + "Highest number of tags a single person has: 1\n"
+                + "Lowest number of tags a single person has: 1\n"
+                + "Total number of tags added to displayed persons: 1";
+        assertCommandSuccess(statsCommand, filteredModel, expectedMessage, filteredModel);
+    }
+}


### PR DESCRIPTION
(#123, #124)

Currently, unable to view statistics of different fields of candidates.

Being able to view certain statistics can help provide quick overviews and help with organisation for the user.

Let's
- Create a new stats command
- Implement the structure needed to support the feature

For now, feature displays statistics about tag count. Can be extended further later on.