### PR TITLE
Add functionality for help command

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/ClearCommand.java
@@ -11,6 +11,11 @@ import seedu.clinkedin.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Clears all entries from the address book.\n"
+            + "Example: " + COMMAND_WORD;
+
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
 

--- a/src/main/java/seedu/clinkedin/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/HelpCommand.java
@@ -6,16 +6,48 @@ import seedu.clinkedin.model.Model;
  * Format full help instructions for every command for display.
  */
 public class HelpCommand extends Command {
-
     public static final String COMMAND_WORD = "help";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+            + "Entering '" + COMMAND_WORD
+            + "' alone will open up a separate window to show help instructions for all commands.\n"
+            + "Entering '" + COMMAND_WORD + " <command>' will show help instructions for the specified command.\n"
+            + "Example: \n\t- " + COMMAND_WORD
+            + "\n\t- " + COMMAND_WORD + " add";
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    private final boolean showHelpWindow;
+
+    private final String shownHelpMessage;
+
+    /**
+     * Creates a default HelpCommand to show help instructions for all commands.
+     * This will open up a separate window to show help instructions for all
+     * commands.
+     */
+    public HelpCommand() {
+        this.showHelpWindow = true;
+        this.shownHelpMessage = "Opened help window.";
+    }
+
+    /**
+     * Creates a HelpCommand to show help instructions for the specified command.
+     * @param commandMessage The help message to be shown.
+     */
+    public HelpCommand(String commandMessage) {
+        this.showHelpWindow = false;
+        this.shownHelpMessage = commandMessage;
+    }
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(shownHelpMessage, showHelpWindow, false);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof HelpCommand // instanceof handles nulls
+                        && showHelpWindow == ((HelpCommand) other).showHelpWindow
+                        && shownHelpMessage.equals(((HelpCommand) other).shownHelpMessage));
     }
 }

--- a/src/main/java/seedu/clinkedin/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/ListCommand.java
@@ -12,6 +12,9 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all candidates in the CLInkedIn address book.\n"
+            + "Example: " + COMMAND_WORD;
+
     public static final String MESSAGE_SUCCESS = "Listed all persons.";
 
     @Override

--- a/src/main/java/seedu/clinkedin/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/AddressBookParser.java
@@ -77,7 +77,7 @@ public class AddressBookParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            return new HelpCommandParser().parse(arguments);
 
         case StatsCommand.COMMAND_WORD:
             return new StatsCommand();

--- a/src/main/java/seedu/clinkedin/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/CliSyntax.java
@@ -2,14 +2,36 @@ package seedu.clinkedin.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import seedu.clinkedin.logic.commands.AddCommand;
+import seedu.clinkedin.logic.commands.AddTagCommand;
+import seedu.clinkedin.logic.commands.ClearCommand;
+import seedu.clinkedin.logic.commands.Command;
+import seedu.clinkedin.logic.commands.CreateTagTypeCommand;
+import seedu.clinkedin.logic.commands.DeleteCommand;
+import seedu.clinkedin.logic.commands.DeleteTagCommand;
+import seedu.clinkedin.logic.commands.EditCommand;
+import seedu.clinkedin.logic.commands.EditTagTypeCommand;
+import seedu.clinkedin.logic.commands.ExportCommand;
+import seedu.clinkedin.logic.commands.FindCommand;
+import seedu.clinkedin.logic.commands.HelpCommand;
+import seedu.clinkedin.logic.commands.ImportCommand;
+import seedu.clinkedin.logic.commands.ListCommand;
+import seedu.clinkedin.logic.commands.NoteCommand;
+import seedu.clinkedin.logic.commands.RateCommand;
+import seedu.clinkedin.logic.commands.StatsCommand;
 import seedu.clinkedin.logic.parser.exceptions.DuplicatePrefixException;
 import seedu.clinkedin.logic.parser.exceptions.PrefixNotFoundException;
 
 /**
- * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
+ * Contains Command Line Interface (CLI) syntax definitions common to multiple
+ * commands
  */
 public class CliSyntax {
 
@@ -36,9 +58,32 @@ public class CliSyntax {
             PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_STATUS));
 
     /**
+     * Contains all user-executable command classes that are used in Clinkedin.
+     */
+    private static final List<Class<? extends Command>> ALL_COMMAND_CLASSES = Arrays.asList(
+            AddCommand.class,
+            AddTagCommand.class,
+            ClearCommand.class,
+            CreateTagTypeCommand.class,
+            DeleteCommand.class,
+            DeleteTagCommand.class,
+            EditCommand.class,
+            EditTagTypeCommand.class,
+            ExportCommand.class,
+            FindCommand.class,
+            HelpCommand.class,
+            ListCommand.class,
+            ImportCommand.class,
+            ListCommand.class,
+            NoteCommand.class,
+            RateCommand.class,
+            StatsCommand.class);
+
+    /**
      * Adds a tag prefix to the list of prefixes.
      * @param pref Prefix to be added.
-     * @throws DuplicatePrefixException If the prefix is already present in the list of prefixes.
+     * @throws DuplicatePrefixException If the prefix is already present in the list
+     *                                  of prefixes.
      */
     public static void addTagPrefix(Prefix pref) throws DuplicatePrefixException {
         if (prefixTags.contains(pref) || prefixes.contains(pref)) {
@@ -51,7 +96,8 @@ public class CliSyntax {
     /**
      * Removes a tag prefix from the list of prefixes.
      * @param pref Prefix to be removed.
-     * @throws PrefixNotFoundException If the prefix doesn't exist in the list of prefixes.
+     * @throws PrefixNotFoundException If the prefix doesn't exist in the list of
+     *                                 prefixes.
      */
     public static void removeTagPrefix(Prefix pref) throws PrefixNotFoundException {
         if (!prefixTags.contains(pref) || !prefixes.contains(pref)) {
@@ -61,6 +107,10 @@ public class CliSyntax {
         prefixes.remove(pref);
     }
 
+    /**
+     * Returns a list of prefixes that are used in Clinkedin.
+     * @return List of prefixes.
+     */
     public static Prefix[] getPrefixes() {
         requireNonNull(prefixes);
         Prefix[] pref = new Prefix[prefixes.size()];
@@ -68,13 +118,64 @@ public class CliSyntax {
         return pref;
     }
 
+    /**
+     * Returns a list of prefixes for tags that are used in Clinkedin.
+     * @return List of prefixes for tags.
+     */
     public static ArrayList<Prefix> getPrefixTags() {
         requireNonNull(prefixTags);
         return prefixTags;
     }
 
+    /**
+     * Returns a list of prefixes that are unique to a person.
+     * @return List of prefixes that are unique to a person.
+     */
     public static ArrayList<Prefix> getUniquePrefixes() {
         requireNonNull(uniquePrefixes);
         return uniquePrefixes;
+    }
+
+    /**
+     * Returns the list of all possible user command classes.
+     * @return List of all possible user command classes.
+     */
+    public static List<Class<? extends Command>> getAllCommandClasses() {
+        return ALL_COMMAND_CLASSES;
+    }
+
+    /**
+     * Returns a map of all possible command words and their corresponding command
+     * message usage instructions.
+     * @return Map of all possible command words and their corresponding usage
+     * @throws NoSuchFieldException     If the command word field is not found in
+     *                                  the class
+     * @throws SecurityException        If the command word field is not accessible
+     * @throws IllegalArgumentException If the command word field is not a string
+     * @throws IllegalAccessException   If the command word field is not accessible
+     */
+    public static Map<String, String> getAllCommandMessages()
+            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        Map<String, String> allCommandMessages = new HashMap<>();
+        try {
+            for (Class<? extends Command> commandClass : ALL_COMMAND_CLASSES) {
+                Field commandWordField = commandClass.getField("COMMAND_WORD");
+                String commandWord = commandWordField.get(null).toString();
+
+                Field commandUsageField = commandClass.getField("MESSAGE_USAGE");
+                String commandUsage = commandUsageField.get(null).toString();
+
+                allCommandMessages.put(commandWord, commandUsage);
+            }
+            return allCommandMessages;
+        } catch (NoSuchFieldException exception) {
+            throw new NoSuchFieldException("No field named COMMAND_WORD found in supplied commands");
+        } catch (SecurityException exception) {
+            throw new SecurityException("Security exception!");
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("Illegal argument exception!");
+        } catch (IllegalAccessException exception) {
+            throw new IllegalAccessException("Illegal access exception!");
+        }
     }
 }

--- a/src/main/java/seedu/clinkedin/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/HelpCommandParser.java
@@ -1,0 +1,42 @@
+package seedu.clinkedin.logic.parser;
+
+import static seedu.clinkedin.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Map;
+
+import seedu.clinkedin.logic.commands.HelpCommand;
+import seedu.clinkedin.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new HelpCommand object
+ */
+public class HelpCommandParser implements Parser<HelpCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the HelpCommand
+     * and returns a HelpCommand object for execution. If the user input is empty, the
+     * help message will be the general help message. If the user input is not empty,
+     * the help message will be the help message of the command that the user inputs.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public HelpCommand parse(String args) throws ParseException {
+        // If no arguments are provided, return the default help command
+        if (args.trim().length() == 0) {
+            return new HelpCommand();
+        }
+        try {
+            // If arguments are provided, parse the arguments and return the help command
+            // associated with the command specified
+            Map<String, String> allCommandMessages = CliSyntax.getAllCommandMessages();
+            if (allCommandMessages.containsKey(args.trim())) {
+                return new HelpCommand(allCommandMessages.get(args.trim()));
+            } else {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            }
+        } catch (Exception e) {
+            // If the argument provided is invalid, throw a parse exception to alert the
+            // user that they have entered an invalid command
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/test/java/seedu/clinkedin/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/HelpCommandTest.java
@@ -1,10 +1,11 @@
 package seedu.clinkedin.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.clinkedin.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.clinkedin.logic.parser.exceptions.ParseException;
 import seedu.clinkedin.model.Model;
 import seedu.clinkedin.model.ModelManager;
 
@@ -14,7 +15,15 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult("Opened help window.", true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_helpWithValidInput_success() {
+        ListCommand testListCommand = new ListCommand();
+        CommandResult expectedCommandResult = new CommandResult(testListCommand.MESSAGE_USAGE, false, false);
+        assertCommandSuccess(new HelpCommand(testListCommand.MESSAGE_USAGE), model, expectedCommandResult,
+                expectedModel);
     }
 }

--- a/src/test/java/seedu/clinkedin/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/HelpCommandTest.java
@@ -1,11 +1,9 @@
 package seedu.clinkedin.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.clinkedin.logic.parser.exceptions.ParseException;
 import seedu.clinkedin.model.Model;
 import seedu.clinkedin.model.ModelManager;
 

--- a/src/test/java/seedu/clinkedin/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/AddressBookParserTest.java
@@ -80,7 +80,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " " + ListCommand.COMMAND_WORD) instanceof HelpCommand);
     }
 
     @Test

--- a/src/test/java/seedu/clinkedin/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/AddressBookParserTest.java
@@ -80,7 +80,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " " + ListCommand.COMMAND_WORD) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " "
+                + ListCommand.COMMAND_WORD) instanceof HelpCommand);
     }
 
     @Test
@@ -91,8 +92,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/clinkedin/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/clinkedin/logic/parser/HelpCommandParserTest.java
@@ -1,0 +1,61 @@
+package seedu.clinkedin.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.clinkedin.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.clinkedin.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.clinkedin.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinkedin.logic.commands.HelpCommand;
+import seedu.clinkedin.logic.commands.ListCommand;
+
+public class HelpCommandParserTest {
+    private final HelpCommandParser parser = new HelpCommandParser();
+
+    @Test
+    public void parse_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
+
+    @Test
+    public void parse_emptyArg_returnsDefaultHelpCommand() {
+        HelpCommand expectedHelpCommand = new HelpCommand();
+        assertParseSuccess(parser, "", expectedHelpCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // No valid command word given
+        assertParseFailure(parser, "This will fail",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsHelpCommand() {
+        // no leading and trailing whitespaces
+        HelpCommand expectedHelpCommand = new HelpCommand(ListCommand.MESSAGE_USAGE);
+        assertParseSuccess(parser, "list", expectedHelpCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n \tlist\t", expectedHelpCommand);
+    }
+
+    @Test
+    public void parse_everyValidCommand_returnsHelpCommand() {
+        try {
+            // Get list of all possible command words
+            Map<String, String> allCommandMessages = CliSyntax.getAllCommandMessages();
+            // Create a help command for every possible command word
+            for (String commandWord : allCommandMessages.keySet()) {
+                // Assert that help command matches command's message usage
+                HelpCommand expectedHelpCommand = new HelpCommand(allCommandMessages.get(commandWord));
+                assertParseSuccess(parser, commandWord, expectedHelpCommand);
+            }
+        } catch (Exception e) {
+            assert false;
+        }
+    }
+}


### PR DESCRIPTION
(Closes #87)
- Previously, the help command would only display a window containing a help window summary of all possible commands.
- This was unintuitive for users who may seek help on a specific help command
- Let's add the functionality to get help for a particular command by extending the help command