### PR TITLE
Update Result Display Window to the side

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="CLInkedIn" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+  title="CLInkedIn" minWidth="1000" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -45,18 +45,15 @@
           </padding>
         </StackPane>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
-
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="400" prefWidth="400" VBox.vgrow="ALWAYS">
           <padding>
             <Insets top="10" right="10" bottom="10" left="10" />
           </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <SplitPane VBox.vgrow="ALWAYS">
+            <StackPane fx:id="personListPanelPlaceholder" minWidth="350" VBox.vgrow="ALWAYS" />
+            <StackPane VBox.vgrow="ALWAYS" fx:id="resultDisplayPlaceholder" minWidth="500" styleClass="pane-with-border">
+            </StackPane>
+          </SplitPane>
         </VBox>
 
         <StackPane fx:id="personCountDisplayPlaceholder" VBox.vgrow="NEVER"/>


### PR DESCRIPTION
(Closes #143)
- Previously, the result display was very crammed at the top of the application.
- As we want to display more information in the result display, let's change the UI of it to appear at the side of the persons card list, rather than on top. 
- Here's a screenshot of what it looks like now:
<img width="998" alt="image" src="https://user-images.githubusercontent.com/48595194/198269867-79301bae-32dc-4093-8783-6f1bdcb3110a.png">
