### PR TITLE
Fix Piechart overlay when executing 'stats'

### DIFF
--- a/src/main/java/seedu/clinkedin/ui/ResultDisplay.java
+++ b/src/main/java/seedu/clinkedin/ui/ResultDisplay.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.beans.binding.Bindings;
+import javafx.beans.value.ChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.chart.PieChart;
@@ -79,7 +80,22 @@ public class ResultDisplay extends UiPart<Region> {
             pieChart.setLabelsVisible(true);
             pieChart.setStartAngle(180);
 
+            placeHolder.alignmentProperty().setValue(javafx.geometry.Pos.BOTTOM_CENTER);
             placeHolder.getChildren().add(pieChart);
+
+            // Event Listener for PieChart alignment
+            // Automatically aligns the pie chart to the center of the screen when the
+            // window height is resized to a size of greater than 550 pixels
+            ChangeListener<Number> windowResizeListener = (observable, oldHeight, newHeight) -> {
+                if (newHeight.doubleValue() > 550) {
+                    placeHolder.alignmentProperty().setValue(javafx.geometry.Pos.CENTER);
+                } else {
+                    placeHolder.alignmentProperty().setValue(javafx.geometry.Pos.BOTTOM_CENTER);
+                }
+            };
+
+            // Bind the event listener to the height of the window
+            placeHolder.heightProperty().addListener(windowResizeListener);
 
             VBox spacing = new VBox(500);
             spacing.setSpacing(150);

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-  title="CLInkedIn" minWidth="1000" minHeight="600" onCloseRequest="#handleExit">
+  title="CLInkedIn" minWidth="1000" minHeight="700" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>


### PR DESCRIPTION
Closes #180 

- Previously, there was an overlap between the result display text and the pie chart when executing the 'stats' command while the window was at the minimum window size.
- Let's increase the default minimum window size to 700 pixels to fix the overlap.
- Let's add a window resize listener that changes the alignment of the chart to prevent this issue from occuring.
- Here's a screenshot of what the default window looks like now:
<img width="997" alt="image" src="https://user-images.githubusercontent.com/48595194/199407998-02c48a20-6eeb-41ac-aef2-b8ade928bfa9.png">
