### PR TITLE
Fix links being displayed as a single line

### DIFF
--- a/src/main/java/seedu/clinkedin/model/person/Person.java
+++ b/src/main/java/seedu/clinkedin/model/person/Person.java
@@ -230,8 +230,8 @@ public class Person {
 
         Set<Link> links = getLinks();
         if (!links.isEmpty()) {
-            builder.append("\nLinks: ");
-            links.forEach(builder::append);
+            builder.append("\nLinks:\n");
+            links.forEach(link -> builder.append(String.format("- %s\n", link.toString())));
         }
 
         builder.append("\n\nStatus: ")


### PR DESCRIPTION
Closes #213 

- Previously, the links of a person was not properly formatted and would display as a single line:
<img width="990" alt="image" src="https://user-images.githubusercontent.com/48595194/199408780-91a2997b-107a-4ce3-8c46-8110d333b0ff.png">

- Let's fix the formatting so that each link is appended and shown in a separate new line:
<img width="987" alt="image" src="https://user-images.githubusercontent.com/48595194/199408859-321df8da-6e11-4dfb-a24d-4efdc55dbb5c.png">
