### PR TITLE
Add test cases for Add-commands

### DIFF
--- a/src/main/java/seedu/clinkedin/model/person/Person.java
+++ b/src/main/java/seedu/clinkedin/model/person/Person.java
@@ -105,6 +105,14 @@ public class Person {
         return tagTypeMap.asUnmodifiableObservableMap();
     }
 
+    /**
+     * Returns an immutable unique tag type map
+     * @return an immutable unique tag type map
+     */
+    public UniqueTagTypeMap getTagTypeMap() {
+        return tagTypeMap;
+    }
+
     public Status getStatus() {
         return status;
     }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -12,15 +12,15 @@
     "rating": "6",
     "links" : [ ]
   }, {
-    "name" : "Benson Meier",
-    "phone" : "98765432",
-    "email" : "johnd@example.com",
-    "address" : "311, Clementi Ave 2, #02-25",
-    "tags" : [ ["Skills", "owesMoney", "friends"] ],
-    "status" : "Rejected",
-    "note" : "He has a good sense of humour.",
-    "rating": "1",
-    "links" : [ ]
+    "name": "Benson Meier",
+    "phone": "98765432",
+    "email": "johnd@example.com",
+    "address": "311, Clementi Ave 2, #02-25",
+    "tags": [["Skills", "owesMoney", "friends"]],
+    "status": "Rejected",
+    "note": "He has a good sense of humour.",
+    "rating": "0",
+    "links": []
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",

--- a/src/test/java/seedu/clinkedin/logic/commands/AddLinkCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddLinkCommandTest.java
@@ -1,10 +1,10 @@
 package seedu.clinkedin.logic.commands;
 
-import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.clinkedin.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.net.MalformedURLException;

--- a/src/test/java/seedu/clinkedin/logic/commands/AddLinkCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddLinkCommandTest.java
@@ -1,0 +1,108 @@
+package seedu.clinkedin.logic.commands;
+
+import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.clinkedin.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinkedin.commons.core.index.Index;
+import seedu.clinkedin.logic.commands.exceptions.CommandException;
+import seedu.clinkedin.model.Model;
+import seedu.clinkedin.model.ModelManager;
+import seedu.clinkedin.model.UserPrefs;
+import seedu.clinkedin.model.link.Link;
+import seedu.clinkedin.model.person.Person;
+
+public class AddLinkCommandTest {
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Set<Link> emptySet = new HashSet<>();
+
+    @Test
+    public void constructor_nullLink_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddLinkCommand(Index.fromZeroBased(0), null));
+    }
+
+    @Test
+    public void constructor_nullIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddLinkCommand(null, emptySet));
+    }
+
+    @Test
+    public void constructor_validParams_success() {
+        assertDoesNotThrow(() -> new AddLinkCommand(Index.fromZeroBased(0), emptySet));
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        AddLinkCommand addLinkCommand = new AddLinkCommand(Index.fromOneBased(100), emptySet);
+        assertThrows(CommandException.class, () -> addLinkCommand.execute(model));
+    }
+
+    @Test
+    public void execute_noChangeInValue_success() {
+        Person personToEdit = model.getFilteredPersonList().get(0);
+        AddLinkCommand addLinkCommand = new AddLinkCommand(Index.fromOneBased(1), personToEdit.getLinks());
+        String expectedMessage = String.format(AddLinkCommand.MESSAGE_ADD_LINKS_SUCCESS, personToEdit);
+        assertCommandSuccess(addLinkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndex_success() throws MalformedURLException {
+        Set<Link> linksToAdd = new HashSet<>();
+        linksToAdd.add(new Link(new URL("https://www.dummylink.com")));
+        Person personToEdit = model.getFilteredPersonList().get(0);
+        AddLinkCommand addLinkCommand = new AddLinkCommand(Index.fromOneBased(1), linksToAdd);
+        linksToAdd.addAll(personToEdit.getLinks());
+        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getTagTypeMap(), personToEdit.getStatus(),
+                personToEdit.getNote(),
+                personToEdit.getRating(), linksToAdd);
+        String expectedMessage = String.format(AddLinkCommand.MESSAGE_ADD_LINKS_SUCCESS, editedPerson);
+        expectedModel.setPerson(personToEdit, editedPerson);
+        assertCommandSuccess(addLinkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals_sameObject() throws MalformedURLException {
+        Set<Link> linksToAdd = new HashSet<>();
+        linksToAdd.add(new Link(new URL("https://www.dummylink.com")));
+        AddLinkCommand command1 = new AddLinkCommand(Index.fromOneBased(1), linksToAdd);
+        assertTrue(command1.equals(command1));
+
+    }
+
+    @Test
+    public void equals_diffObjectSameParameters() throws MalformedURLException {
+        Set<Link> linksToAdd = new HashSet<>();
+        linksToAdd.add(new Link(new URL("https://www.dummylink.com")));
+        AddLinkCommand command1 = new AddLinkCommand(Index.fromOneBased(1), linksToAdd);
+        AddLinkCommand command2 = new AddLinkCommand(Index.fromOneBased(1), linksToAdd);
+        assertTrue(command1.equals(command2));
+    }
+
+    @Test
+    public void notEqual_null() throws MalformedURLException {
+        Set<Link> linksToAdd = new HashSet<>();
+        linksToAdd.add(new Link(new URL("https://www.dummylink.com")));
+        AddLinkCommand command1 = new AddLinkCommand(Index.fromOneBased(1), linksToAdd);
+        assertFalse(command1.equals(null));
+    }
+
+    @Test
+    public void notEqual_differentType() throws MalformedURLException {
+        Set<Link> linksToAdd = new HashSet<>();
+        linksToAdd.add(new Link(new URL("https://www.dummylink.com")));
+        AddLinkCommand command1 = new AddLinkCommand(Index.fromOneBased(1), linksToAdd);
+        assertFalse(command1.equals(5));
+    }
+}

--- a/src/test/java/seedu/clinkedin/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddNoteCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.clinkedin.logic.commands;
 
+import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,6 +9,7 @@ import static seedu.clinkedin.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.Test;
 
 import seedu.clinkedin.commons.core.index.Index;
+import seedu.clinkedin.logic.commands.exceptions.CommandException;
 import seedu.clinkedin.model.Model;
 import seedu.clinkedin.model.ModelManager;
 import seedu.clinkedin.model.UserPrefs;
@@ -41,6 +43,27 @@ public class AddNoteCommandTest {
         Person personToEdit = model.getFilteredPersonList().get(0);
         AddNoteCommand addNoteCommand = new AddNoteCommand(Index.fromOneBased(1), personToEdit.getNote());
         assertThrows(DuplicateNoteException.class, () -> addNoteCommand.execute(model));
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Note note = new Note("She is strong at Java.");
+        AddNoteCommand addNoteCommand = new AddNoteCommand(Index.fromOneBased(100), note);
+        assertThrows(CommandException.class, () -> addNoteCommand.execute(model));
+    }
+
+    @Test
+    public void execute_validIndex_success() {
+        Note note = new Note("She graduates in 1 year.");
+        AddNoteCommand addNoteCommand = new AddNoteCommand(Index.fromOneBased(1), note);
+        Person personToEdit = model.getFilteredPersonList().get(0);
+        Note newNote = personToEdit.mergeNote(note);
+        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getTagTypeMap(), personToEdit.getStatus(), newNote,
+                personToEdit.getRating(), personToEdit.getLinks());
+        String expectedMessage = String.format(AddNoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedPerson);
+        expectedModel.setPerson(personToEdit, editedPerson);
+        assertCommandSuccess(addNoteCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/clinkedin/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddNoteCommandTest.java
@@ -1,9 +1,9 @@
 package seedu.clinkedin.logic.commands;
 
-import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.clinkedin.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/clinkedin/logic/commands/AddRateCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddRateCommandTest.java
@@ -3,6 +3,7 @@ package seedu.clinkedin.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.clinkedin.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,35 @@ public class AddRateCommandTest {
         Person personToEdit = model.getFilteredPersonList().get(0);
         AddRateCommand rateCommand = new AddRateCommand(Index.fromOneBased(1), personToEdit.getRating());
         assertThrows(CommandException.class, () -> rateCommand.execute(model));
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Rating rating = new Rating("6");
+        AddRateCommand rateCommand = new AddRateCommand(Index.fromOneBased(100), rating);
+        assertThrows(CommandException.class, () -> rateCommand.execute(model));
+    }
+
+    @Test
+    public void execute_personHasRatingAlready_throwsCommandException() {
+        Rating rating = new Rating("6");
+        AddRateCommand rateCommand = new AddRateCommand(Index.fromOneBased(1), rating);
+        assertThrows(CommandException.class, () -> rateCommand.execute(model));
+    }
+
+    @Test
+    public void execute_validIndex_success() {
+        Person personToEdit = model.getFilteredPersonList().get(1);
+        Rating rating = new Rating("6");
+        AddRateCommand rateCommand = new AddRateCommand(Index.fromOneBased(2), rating);
+        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getTagTypeMap(),
+                personToEdit.getStatus(), personToEdit.getNote(), rating, personToEdit.getLinks());
+
+        String expectedMessage = String.format(AddRateCommand.MESSAGE_ADD_RATING_SUCCESS, editedPerson);
+
+        expectedModel.setPerson(personToEdit, editedPerson);
+        assertCommandSuccess(rateCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/clinkedin/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddTagCommandTest.java
@@ -3,8 +3,8 @@ package seedu.clinkedin.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.clinkedin.testutil.Assert.assertThrows;
 import static seedu.clinkedin.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinkedin.testutil.Assert.assertThrows;
 import static seedu.clinkedin.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.nio.file.Path;

--- a/src/test/java/seedu/clinkedin/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/clinkedin/testutil/TypicalPersons.java
@@ -35,7 +35,7 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
                     .withAddress("311, Clementi Ave 2, #02-25").withNote("He has a good sense of humour.")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").withStatus("Rejected").withRating("1").build();
+                    .withTags("owesMoney", "friends").withStatus("Rejected").withRating("0").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withStatus("OA Received")
             .withRating("4").build();


### PR DESCRIPTION
- Previously, the test coverage percentage was pretty low for the new add-commands, especially because we switched formats
<img width="766" alt="image" src="https://user-images.githubusercontent.com/48595194/199472176-9c84b5e3-6f00-4216-9b6a-c28d0cf72ff6.png">

- Let's add more tests to increase code coverage for add commands