### PR TITLE
Fix immutability issues related to Uniquetagtypemap

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/EditCommand.java
@@ -106,7 +106,6 @@ public class EditCommand extends Command {
         try {
             Person personToEdit = lastShownList.get(index.getZeroBased());
             Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
-
             if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
                 throw new CommandException(MESSAGE_DUPLICATE_PERSON);
             }
@@ -137,9 +136,9 @@ public class EditCommand extends Command {
         original.setTagTypeMap(personToEditTags);
         UniqueTagTypeMap toEdit = editPersonDescriptor.getOldTagTypeMap().get();
         UniqueTagTypeMap editTo = editPersonDescriptor.getNewTagTypeMap().get();
-
         original.removeTags(toEdit);
         original.mergeTagTypeMap(editTo);
+
         UniqueTagTypeMap updatedTags = original;
         Note updatedNote = editPersonDescriptor.getNote().orElse(personToEdit.getNote());
         Status updatedStatus = editPersonDescriptor.getStatus().orElse(personToEdit.getStatus());

--- a/src/main/java/seedu/clinkedin/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/CliSyntax.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -125,7 +126,7 @@ public class CliSyntax {
      */
     public static void setTagPrefix(List<Prefix> pref) {
         prefixes.removeAll(prefixTags);
-        prefixTags = new ArrayList<>(pref);
+        prefixTags = new ArrayList<>(pref.stream().map(p -> p.copy()).collect(Collectors.toList()));
         prefixes.addAll(prefixTags);
     }
 

--- a/src/main/java/seedu/clinkedin/logic/parser/Prefix.java
+++ b/src/main/java/seedu/clinkedin/logic/parser/Prefix.java
@@ -55,4 +55,11 @@ public class Prefix {
     public static boolean isValidPrefixName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
+
+    /**
+     * Returns a copy of the prefix.
+     */
+    public Prefix copy() {
+        return new Prefix(prefix);
+    }
 }

--- a/src/main/java/seedu/clinkedin/model/tag/Tag.java
+++ b/src/main/java/seedu/clinkedin/model/tag/Tag.java
@@ -60,4 +60,11 @@ public class Tag {
     public String getTagName() {
         return tagName;
     }
+
+    /**
+     * Returns a copy of the tag.
+     */
+    public Tag copy() {
+        return new Tag(this.tagName);
+    }
 }

--- a/src/main/java/seedu/clinkedin/model/tag/TagType.java
+++ b/src/main/java/seedu/clinkedin/model/tag/TagType.java
@@ -78,4 +78,11 @@ public class TagType {
     public Prefix getPrefix() {
         return this.p;
     }
+
+    /**
+     * Returns a copy of the tag type.
+     */
+    public TagType copy() {
+        return new TagType(tagType, p.copy());
+    }
 }

--- a/src/main/java/seedu/clinkedin/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/clinkedin/model/tag/UniqueTagList.java
@@ -221,4 +221,15 @@ public class UniqueTagList implements Iterable<Tag> {
     public List<String> getAsList() {
         return internalList.stream().map(tag -> tag.getTagName()).collect(Collectors.toList());
     }
+
+    /**
+     * Returns a copy of the UniqueTagList.
+     */
+    public UniqueTagList copy() {
+        UniqueTagList clone = new UniqueTagList();
+        for (Tag t : this) {
+            clone.add(t.copy());
+        }
+        return clone;
+    }
 }

--- a/src/test/java/seedu/clinkedin/model/person/UniqueTagTypeMapTest.java
+++ b/src/test/java/seedu/clinkedin/model/person/UniqueTagTypeMapTest.java
@@ -1,0 +1,116 @@
+package seedu.clinkedin.model.person;
+
+import org.junit.jupiter.api.Test;
+
+class UniqueTagTypeMapTest {
+
+    private final UniqueTagTypeMap uniqueTagTypeMap = new UniqueTagTypeMap();
+
+    @Test
+    void createTagType() {
+    }
+
+    @Test
+    void removeExistingTagType() {
+    }
+
+    @Test
+    void setExistingTagType() {
+    }
+
+    @Test
+    void contains() {
+    }
+
+    @Test
+    void mergeTagTypeMap() {
+    }
+
+    @Test
+    void removeTags() {
+    }
+
+    @Test
+    void mergeTag() {
+    }
+
+    @Test
+    void setTagType() {
+    }
+
+    @Test
+    void removeTagType() {
+    }
+
+    @Test
+    void getTagList() {
+    }
+
+    @Test
+    void setTagTypeMap() {
+    }
+
+    @Test
+    void testSetTagTypeMap() {
+    }
+
+    @Test
+    void getCount() {
+    }
+
+    @Test
+    void getTagCount() {
+    }
+
+    @Test
+    void asUnmodifiableObservableMap() {
+    }
+
+    @Test
+    void iterator() {
+    }
+
+    @Test
+    void getPrefixMap() {
+    }
+
+    @Test
+    void setPrefixMap() {
+    }
+
+    @Test
+    void testEquals() {
+    }
+
+    @Test
+    void testHashCode() {
+    }
+
+    @Test
+    void toStream() {
+    }
+
+    @Test
+    void getTagType() {
+    }
+
+    @Test
+    void testToString() {
+    }
+
+    @Test
+    void getPrefixFromTagType() {
+    }
+
+    @Test
+    void getTagTypeFromPrefix() {
+    }
+
+    @Test
+    void isEmpty() {
+    }
+
+    @Test
+    void isExist() {
+    }
+}

--- a/src/test/java/seedu/clinkedin/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/clinkedin/testutil/TypicalPersons.java
@@ -35,7 +35,7 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
                     .withAddress("311, Clementi Ave 2, #02-25").withNote("He has a good sense of humour.")
             .withEmail("johnd@example.com").withPhone("98765432")
-                    .withTags("owesMoney", "friends").withStatus("Rejected").withRating("0").build();
+                    .withTags("owesMoney", "enemies").withStatus("Rejected").withRating("0").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withStatus("OA Received")
             .withRating("4").build();

--- a/src/test/java/seedu/clinkedin/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/clinkedin/testutil/TypicalPersons.java
@@ -35,7 +35,7 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
                     .withAddress("311, Clementi Ave 2, #02-25").withNote("He has a good sense of humour.")
             .withEmail("johnd@example.com").withPhone("98765432")
-                    .withTags("owesMoney", "enemies").withStatus("Rejected").withRating("0").build();
+                    .withTags("owesMoney", "friends").withStatus("Rejected").withRating("0").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withStatus("OA Received")
             .withRating("4").build();


### PR DESCRIPTION
Previously some methods of `UniqueTagTypeMap` weren't immutable, which led to undesirable behaviour. For example, some undo commands weren't working. (To note: still undo doesn't work for tagtype commands).