### PR TITLE
Fix Undo and Redo command

### DIFF
--- a/src/main/java/seedu/clinkedin/logic/commands/CreateTagTypeCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/CreateTagTypeCommand.java
@@ -47,6 +47,8 @@ public class CreateTagTypeCommand extends Command {
         } catch (DuplicatePrefixException | DuplicateTagTypeException d) {
             throw new CommandException(d.getMessage());
         }
+        model.setPrefixMap(UniqueTagTypeMap.getPrefixMap());
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/clinkedin/logic/commands/DeleteTagTypeCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/DeleteTagTypeCommand.java
@@ -41,6 +41,8 @@ public class DeleteTagTypeCommand extends Command {
         }
 
         model.deleteTagTypeForAllPerson(toDelete);
+        model.setPrefixMap(UniqueTagTypeMap.getPrefixMap());
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_DELETE_TAG_TYPE_SUCCESS, toDelete));
     }
 

--- a/src/main/java/seedu/clinkedin/logic/commands/EditTagTypeCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/EditTagTypeCommand.java
@@ -54,6 +54,8 @@ public class EditTagTypeCommand extends Command {
                 | DuplicateTagTypeException | DuplicatePrefixException | TagTypePrefixPairNotFoundException e) {
             throw new CommandException(e.getMessage());
         }
+        model.setPrefixMap(UniqueTagTypeMap.getPrefixMap());
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_EDIT_TAG_TYPE_SUCCESS, editToTagType));
     }
 

--- a/src/main/java/seedu/clinkedin/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/clinkedin/logic/commands/ImportCommand.java
@@ -93,7 +93,7 @@ public class ImportCommand extends Command {
         for (Person person : personList) {
             if (!model.hasPerson(person)) {
                 isUpdated = true;
-                model.addPerson(person);
+                model.addPersonWithoutCommitting(person);
             } else {
                 isSomeExisting = true;
             }
@@ -118,6 +118,7 @@ public class ImportCommand extends Command {
             if (isNewCreated) {
                 returnMessage.append(" " + MESSAGE_NEW_TAGTYPES);
             }
+            model.commitAddressBook();
             return new CommandResult(returnMessage.toString());
         }
         return new CommandResult(String.format(MESSAGE_NO_CHANGE, filePath));

--- a/src/main/java/seedu/clinkedin/model/AddressBook.java
+++ b/src/main/java/seedu/clinkedin/model/AddressBook.java
@@ -2,6 +2,7 @@ package seedu.clinkedin.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -19,7 +20,7 @@ import seedu.clinkedin.model.tag.TagType;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
-    private final Map<Prefix, TagType> prefixMap;
+    private Map<Prefix, TagType> prefixMap;
 
     /*
      * The 'unusual' code block below is a non-static initialization block,
@@ -33,7 +34,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
-        prefixMap = UniqueTagTypeMap.getPrefixMap();
+        prefixMap = UniqueTagTypeMap.getPrefixMapCopy();
     }
 
     public AddressBook() {
@@ -62,7 +63,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
-
         setPersons(newData.getPersonList());
     }
 
@@ -121,10 +121,12 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     @Override
     public Map<Prefix, TagType> getPrefixMap() {
-        return prefixMap;
+        return Collections.unmodifiableMap(prefixMap);
     }
 
     public void setPrefixMap(Map<Prefix, TagType> prefixMap) {
+        this.prefixMap.clear();
+        this.prefixMap.putAll(prefixMap);
         UniqueTagTypeMap.setPrefixMap(prefixMap);
     }
 

--- a/src/main/java/seedu/clinkedin/model/Model.java
+++ b/src/main/java/seedu/clinkedin/model/Model.java
@@ -91,6 +91,8 @@ public interface Model {
      */
     void addPerson(Person person);
 
+    void addPersonWithoutCommitting(Person person);
+
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.

--- a/src/main/java/seedu/clinkedin/model/Model.java
+++ b/src/main/java/seedu/clinkedin/model/Model.java
@@ -4,10 +4,12 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.DoubleSummaryStatistics;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.clinkedin.commons.core.GuiSettings;
+import seedu.clinkedin.logic.parser.Prefix;
 import seedu.clinkedin.model.person.Person;
 import seedu.clinkedin.model.tag.TagType;
 
@@ -139,4 +141,6 @@ public interface Model {
     void deleteTagTypeForAllPerson(TagType toDelete);
 
     void editTagTypeForAllPerson(TagType toEdit, TagType editTo);
+
+    void setPrefixMap(Map<Prefix, TagType> prefixMap);
 }

--- a/src/main/java/seedu/clinkedin/model/ModelManager.java
+++ b/src/main/java/seedu/clinkedin/model/ModelManager.java
@@ -237,6 +237,7 @@ public class ModelManager implements Model {
         List<Person> sortedList = new ArrayList<>(addressBook.getPersonList());
         sortedList.sort(comparator);
         addressBook.setPersons(sortedList);
+        commitAddressBook();
     }
 
     @Override

--- a/src/main/java/seedu/clinkedin/model/ModelManager.java
+++ b/src/main/java/seedu/clinkedin/model/ModelManager.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 import java.util.DoubleSummaryStatistics;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -18,6 +19,7 @@ import seedu.clinkedin.commons.core.GuiSettings;
 import seedu.clinkedin.commons.core.LogsCenter;
 import seedu.clinkedin.commons.exceptions.CannotRedoAddressBookException;
 import seedu.clinkedin.commons.exceptions.CannotUndoAddressBookException;
+import seedu.clinkedin.logic.parser.Prefix;
 import seedu.clinkedin.model.person.Person;
 import seedu.clinkedin.model.person.UniqueTagTypeMap;
 import seedu.clinkedin.model.tag.TagType;
@@ -239,8 +241,18 @@ public class ModelManager implements Model {
     @Override
     public void deleteTagTypeForAllPerson(TagType toDelete) {
         List<Person> personList = addressBook.getPersonList();
-        personList.stream().forEach(x -> x.deleteTagType(toDelete));
-        addressBook.setPersons(personList);
+        List<Person> updatedPersonList = new ArrayList<>();
+        for (Person p: personList) {
+            UniqueTagTypeMap tagTypeMap = new UniqueTagTypeMap();
+            tagTypeMap.setTagTypeMap(p.getTags());
+            if (p.getTags().keySet().contains(toDelete)) {
+                tagTypeMap.removeTagType(toDelete);
+            }
+            updatedPersonList.add(new Person(p.getName(), p.getPhone(), p.getEmail(), p.getAddress(), tagTypeMap,
+                    p.getStatus(), p.getNote(), p.getRating(), p.getLinks()));
+        }
+        addressBook.setPersons(updatedPersonList);
+
     }
 
     /**
@@ -251,12 +263,12 @@ public class ModelManager implements Model {
         List<Person> updatedPersonList = new ArrayList<>();
         for (Person p: personList) {
             UniqueTagTypeMap tagTypeMap = new UniqueTagTypeMap();
+            tagTypeMap.setTagTypeMap(p.getTags());
             if (p.getTags().keySet().contains(toEdit)) {
-                tagTypeMap.setTagTypeMap(p.getTags());
                 tagTypeMap.setTagType(toEdit, editTo);
-                p.setTagTypeMap(tagTypeMap);
             }
-            updatedPersonList.add(p);
+            updatedPersonList.add(new Person(p.getName(), p.getPhone(), p.getEmail(), p.getAddress(), tagTypeMap,
+                    p.getStatus(), p.getNote(), p.getRating(), p.getLinks()));
         }
         addressBook.setPersons(updatedPersonList);
     }
@@ -278,6 +290,11 @@ public class ModelManager implements Model {
         return addressBook.equals(other.addressBook)
                 && userPrefs.equals(other.userPrefs)
                 && filteredPersons.equals(other.filteredPersons);
+    }
+
+    @Override
+    public void setPrefixMap(Map<Prefix, TagType> prefixMap) {
+        this.addressBook.setPrefixMap(prefixMap);
     }
 
 }

--- a/src/main/java/seedu/clinkedin/model/ModelManager.java
+++ b/src/main/java/seedu/clinkedin/model/ModelManager.java
@@ -156,6 +156,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void addPersonWithoutCommitting(Person person) {
+        addressBook.addPerson(person);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 

--- a/src/main/java/seedu/clinkedin/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/clinkedin/model/VersionedAddressBook.java
@@ -3,13 +3,19 @@ package seedu.clinkedin.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javafx.collections.ObservableList;
 import seedu.clinkedin.commons.exceptions.CannotRedoAddressBookException;
 import seedu.clinkedin.commons.exceptions.CannotUndoAddressBookException;
+import seedu.clinkedin.logic.parser.Prefix;
 import seedu.clinkedin.model.person.Person;
 import seedu.clinkedin.model.person.UniquePersonList;
+import seedu.clinkedin.model.person.UniqueTagTypeMap;
+import seedu.clinkedin.model.tag.TagType;
 
 /**
  * Subclass of AddressBook that stores the state of the AddressBook at a particular point in time.
@@ -19,6 +25,7 @@ import seedu.clinkedin.model.person.UniquePersonList;
 public class VersionedAddressBook extends AddressBook {
 
     private final UniquePersonList persons;
+    private Map<Prefix, TagType> prefixMap;
 
     private final List<ReadOnlyAddressBook> addressBookStateList;
 
@@ -36,6 +43,7 @@ public class VersionedAddressBook extends AddressBook {
      */
     {
         persons = new UniquePersonList();
+        prefixMap = UniqueTagTypeMap.getPrefixMapCopy();
     }
 
     /**
@@ -79,7 +87,8 @@ public class VersionedAddressBook extends AddressBook {
     public void commit() {
         requireNonNull(addressBookStateList);
         removeStatesAfterCurrentPointer();
-        addressBookStateList.add(new AddressBook(this));
+        AddressBook toAdd = new AddressBook(this);
+        addressBookStateList.add(toAdd);
         currentStatePointer = addressBookStateList.size() - 1;
     }
 
@@ -142,8 +151,12 @@ public class VersionedAddressBook extends AddressBook {
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
-
+        this.prefixMap = new HashMap<>();
+        for (Prefix p : newData.getPrefixMap().keySet()) {
+            prefixMap.put(p.copy(), newData.getPrefixMap().get(p).copy());
+        }
         setPersons(newData.getPersonList());
+        UniqueTagTypeMap.setPrefixMap(prefixMap);
     }
 
     //// person-level operations
@@ -218,5 +231,16 @@ public class VersionedAddressBook extends AddressBook {
     @Override
     public int hashCode() {
         return persons.hashCode();
+    }
+
+    @Override
+    public Map<Prefix, TagType> getPrefixMap() {
+        return Collections.unmodifiableMap(prefixMap);
+    }
+    @Override
+    public void setPrefixMap(Map<Prefix, TagType> prefixMap) {
+        this.prefixMap.clear();
+        this.prefixMap.putAll(prefixMap);
+        UniqueTagTypeMap.setPrefixMap(prefixMap);
     }
 }

--- a/src/main/java/seedu/clinkedin/model/person/Person.java
+++ b/src/main/java/seedu/clinkedin/model/person/Person.java
@@ -302,4 +302,5 @@ public class Person {
         }
         return new Note(this.note.value + "\n" + note.value);
     }
+
 }

--- a/src/main/java/seedu/clinkedin/model/person/UniqueTagTypeMap.java
+++ b/src/main/java/seedu/clinkedin/model/person/UniqueTagTypeMap.java
@@ -261,6 +261,14 @@ public class UniqueTagTypeMap implements Iterable<TagType> {
         return Collections.unmodifiableMap(prefixMap);
     }
 
+    public static Map<Prefix, TagType> getPrefixMapCopy() {
+        Map<Prefix, TagType> copy = new HashMap<>();
+        for (Prefix p : prefixMap.keySet()) {
+            copy.put(p.copy(), prefixMap.get(p).copy());
+        }
+        return copy;
+    }
+
     public static void setPrefixMap(Map<Prefix, TagType> map) {
         Map<Prefix, TagType> newMap = new HashMap<>();
         for (Prefix p: map.keySet()) {
@@ -320,5 +328,18 @@ public class UniqueTagTypeMap implements Iterable<TagType> {
 
     public static boolean isExist(String otherTagType) {
         return prefixMap.values().stream().anyMatch(tagType -> tagType.getTagTypeName().equals(otherTagType));
+    }
+
+    /**
+     * Returns a copy of the UniqueTagTypeMap.
+     */
+    public UniqueTagTypeMap copy() {
+        UniqueTagTypeMap copy = new UniqueTagTypeMap();
+        for (TagType tagType: this) {
+            for (Tag tag: this.getTagList(tagType)) {
+                copy.mergeTag(tagType, tag);
+            }
+        }
+        return copy;
     }
 }

--- a/src/test/java/seedu/clinkedin/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddCommandTest.java
@@ -224,6 +224,11 @@ public class AddCommandTest {
         public void setPrefixMap(Map<Prefix, TagType> prefixMap) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void addPersonWithoutCommitting(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/clinkedin/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddCommandTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.DoubleSummaryStatistics;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.ObservableList;
 import seedu.clinkedin.commons.core.GuiSettings;
 import seedu.clinkedin.logic.commands.exceptions.CommandException;
+import seedu.clinkedin.logic.parser.Prefix;
 import seedu.clinkedin.model.AddressBook;
 import seedu.clinkedin.model.Model;
 import seedu.clinkedin.model.ReadOnlyAddressBook;
@@ -215,6 +217,11 @@ public class AddCommandTest {
 
         @Override
         public HashMap<String, Integer> getRatingCount() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPrefixMap(Map<Prefix, TagType> prefixMap) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/clinkedin/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddTagCommandTest.java
@@ -281,6 +281,10 @@ public class AddTagCommandTest {
         public void setPrefixMap(Map<Prefix, TagType> prefixMap) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public void addPersonWithoutCommitting(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/clinkedin/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/clinkedin/logic/commands/AddTagCommandTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.DoubleSummaryStatistics;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import javafx.collections.ObservableList;
 import seedu.clinkedin.commons.core.GuiSettings;
 import seedu.clinkedin.commons.core.index.Index;
 import seedu.clinkedin.logic.commands.exceptions.CommandException;
+import seedu.clinkedin.logic.parser.Prefix;
 import seedu.clinkedin.model.AddressBook;
 import seedu.clinkedin.model.Model;
 import seedu.clinkedin.model.ModelManager;
@@ -273,6 +275,10 @@ public class AddTagCommandTest {
 
         @Override
         public HashMap<String, Integer> getRatingCount() {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public void setPrefixMap(Map<Prefix, TagType> prefixMap) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/clinkedin/model/person/UniqueTagTypeMapTest.java
+++ b/src/test/java/seedu/clinkedin/model/person/UniqueTagTypeMapTest.java
@@ -2,9 +2,16 @@ package seedu.clinkedin.model.person;
 
 import org.junit.jupiter.api.Test;
 
+import static seedu.clinkedin.testutil.Assert.assertThrows;
+
 class UniqueTagTypeMapTest {
 
     private final UniqueTagTypeMap uniqueTagTypeMap = new UniqueTagTypeMap();
+
+    @Test
+    public void contains_nullTagType_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueTagTypeMap.contains(null));
+    }
 
     @Test
     void createTagType() {

--- a/src/test/java/seedu/clinkedin/model/person/UniqueTagTypeMapTest.java
+++ b/src/test/java/seedu/clinkedin/model/person/UniqueTagTypeMapTest.java
@@ -1,8 +1,8 @@
 package seedu.clinkedin.model.person;
 
-import org.junit.jupiter.api.Test;
-
 import static seedu.clinkedin.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 class UniqueTagTypeMapTest {
 


### PR DESCRIPTION
Previously, the undo and redo command didn't work for some commands like `Tag`, `TagType`, `import`, `sort` commands. Let's fix this.